### PR TITLE
Fix for stop() not halting light.blink()

### DIFF
--- a/library/explorerhat.py
+++ b/library/explorerhat.py
@@ -414,8 +414,10 @@ class Output(Pin):
         if self.fader != None:
             self.fader.stop()
 
-        self.blinking = False
-        self.stop_pulse()
+        if self.blinking:
+            self.blink(0,1)
+            self.blinking = False
+            self.stop_pulse()
 
         # Abruptly stopping PWM is a bad idea
         # unless we're writing a 1 or 0
@@ -435,9 +437,9 @@ class Output(Pin):
         self.pulser = Pulse(self,0,0,0,0)
 
     def write(self,value):
-        blinking = self.blinking
 
         self.stop()
+        blinking = self.blinking
 
         self.duty_cycle(100)
         self.gpio_pwm.stop()

--- a/library/explorerhat.py
+++ b/library/explorerhat.py
@@ -415,7 +415,7 @@ class Output(Pin):
             self.fader.stop()
 
         if self.blinking:
-            self.blink(0,1)
+            self.blink(0,1) #need this to stop on() failing initially
             self.blinking = False
             self.stop_pulse()
 


### PR DESCRIPTION
If you set an LED blinking with light.blink(), it will not stop if you call light.stop().

This small changes fixes that, I think. 

Tested on a EH and EH Pro.
