### PR TITLE
changed IOError to a basic Exception to get explorerphat running with…

### DIFF
--- a/library/explorerhat/__init__.py
+++ b/library/explorerhat/__init__.py
@@ -691,7 +691,7 @@ GPIO.setwarnings(False)
 try:
     _cap1208 = Cap1208()
     has_captouch = True
-except IOError:
+except Exception:
     has_captouch = False
 
 if adc_available:


### PR DESCRIPTION
… python 3.5

http://forums.pimoroni.com/t/explorerphat-pi3-archlinux-product-id-5-not-supported/2705
