### PR TITLE
Defer setup to avoid module import-time side-effects

### DIFF
--- a/library/explorerhat/__init__.py
+++ b/library/explorerhat/__init__.py
@@ -91,46 +91,44 @@ def help(topic=None):
     return _help[topic]
 
 
-class Default():
+class Default(object):
+    """Stand-in for ObjectCollection used to ensure one-time setup.
+
+    """
+
     def __init__(self, parent_name=None, **kwargs):
+        object.__init__(self)
         self._parent_name = parent_name
-        self._parent = None
 
     def _ensure_setup(self):
-        setup()
-        self._parent = globals()[self._parent_name]
+        if not _is_setup:
+            setup()
+        self._ensure_setup = lambda: globals()[self._parent_name]
+        return globals()[self._parent_name]
 
     def __iter__(self):
-        self._ensure_setup()
-        return self._parent.__iter__()
+        return self._ensure_setup().__iter__()
 
     def __call__(self):
-        self._ensure_setup()
-        return self._parent.__call__()
+        return self._ensure_setup().__call__()
 
     def __repr__(self):
-        self._ensure_setup()
-        return self._parent.__repr__()
-
-    def __str__(self):
-        self._ensure_setup()
-        return self._parent.__str__()
+        return self._ensure_setup().__repr__()
 
     def __len__(self):
-        self._ensure_setup()
-        return self._parent.__len__()
+        return self._ensure_setup().__len__()
 
     def __dir__(self):
-        self._ensure_setup()
-        return self._parent.__dir__()
+        return self._ensure_setup().__dir__()
 
-    def __getattr__(self, name):
-        self._ensure_setup()
-        return self._parent.__getattr__(name)
+    def __getattribute__(self, name):
+        if name in ("_parent_name", "_ensure_setup"):
+            return object.__getattribute__(self, name)
+
+        return self._ensure_setup().__getattr__(name)
 
     def __getitem__(self, key):
-        self._ensure_setup()
-        return self._parent.__getitem__(key)
+        return self._ensure_setup().__getitem__(key)
 
 
 settings = Default('settings')

--- a/library/explorerhat/__init__.py
+++ b/library/explorerhat/__init__.py
@@ -47,7 +47,9 @@ analog = None
 touch = None
 motor = None
 
+_cap1208 = None
 _quiet = False
+_is_setup = False
 
 # Assume A+, B+ and no funny business
 
@@ -764,19 +766,19 @@ def explorerhat_exit():
     if not _quiet:
         print("Goodbye!")
 
-def setup(*args, **kwargs):
-    _setup(*args, **kwargs)
 
-def _setup(quiet=False):
+def setup(quiet=False):
     """Setup Explorer HAT or pHAT"""
 
-    global _cap1208, setup, settings, light, output, input, touch, analog, motor
+    global _cap1208, _is_setup, settings, light, output, input, touch, analog, motor
     global _quiet, has_captouch, has_analog, explorer_pro, explorer_phat
 
     _quiet = quiet
 
-    def setup(*args, **kwargs):
-        return True
+    if _is_setup:
+        raise RuntimeError("Setup has already run,\nplease call explorerhat.setup() before any other method.")
+
+    _is_setup = True
 
     GPIO.setmode(GPIO.BCM)
     GPIO.setwarnings(False)

--- a/library/explorerhat/__init__.py
+++ b/library/explorerhat/__init__.py
@@ -664,7 +664,7 @@ class AnalogInput(object):
 
     def read(self):
         if not setup_analog():
-            RuntimeError("Analog is unavailable, check your pHAT/HAT and/or connections!")
+            raise RuntimeError("Analog is unavailable, check your pHAT/HAT and/or connections!")
         return read_se_adc(self.channel)
 
     def sensitivity(self, sensitivity):

--- a/library/explorerhat/__init__.py
+++ b/library/explorerhat/__init__.py
@@ -95,7 +95,7 @@ class Default():
         self._parent = None
 
     def _ensure_setup(self):
-        ensure_setup()
+        setup()
         self._parent = globals()[self._parent_name]
 
     def __iter__(self):
@@ -764,16 +764,19 @@ def explorerhat_exit():
     if not _quiet:
         print("Goodbye!")
 
-ensure_setup = lambda: setup()
+def setup(*args, **kwargs):
+    _setup(*args, **kwargs)
 
-def setup(quiet=False):
+def _setup(quiet=False):
     """Setup Explorer HAT or pHAT"""
 
-    global _cap1208, ensure_setup, settings, light, output, input, touch, analog, motor
+    global _cap1208, setup, settings, light, output, input, touch, analog, motor
     global _quiet, has_captouch, has_analog, explorer_pro, explorer_phat
 
     _quiet = quiet
-    ensure_setup = lambda: True
+
+    def setup(*args, **kwargs):
+        return True
 
     GPIO.setmode(GPIO.BCM)
     GPIO.setwarnings(False)
@@ -862,6 +865,8 @@ def setup(quiet=False):
     except RuntimeError:
         raise RuntimeError("YOu must be root to use Explorer HAT!")
         ready = False
+
+    return True
 
 
 _help = {


### PR DESCRIPTION
This PR makes several "friendly neighbour" changes to the Explorer HAT library:

* Do not perform any module setup on import
* Do not output any messages/text on import
* Use ImportError instead of hard exit() for "friendly" import error messages

An experimental `Default` class, which shadows all the methods used in Explorer HATs `ObjectCollection` class is used to trap calls to the library and call `ensure_setup` before handing them off to the correct class.

The default class is triggered only once. After this default class has been triggered, it will be replaced by instances of the actual Motor, Input, Output, etc classes for subsequent calls.

The `setup` method will be called automatically by the first call to an Explorer HAT method. It will raise a `RuntimeError` if run again. If you want to `setup` with custom settings - ie: `quiet` mode - then `explorerhat.setup()` should be the first thing you call after import.

See here for details of the problems import-time side-effects can have: https://www.raspberrypi.org/forums/viewtopic.php?f=32&t=193502&p=1212488#p1212488