### PR TITLE
Fix thread.isAlive for py3.9

### DIFF
--- a/library/explorerhat/pins.py
+++ b/library/explorerhat/pins.py
@@ -11,13 +11,19 @@ class StoppableThread(threading.Thread):
         self.stop_event = threading.Event()
         self.daemon = True
 
+    def alive(self):
+        try:
+            return self.isAlive()
+        except AttributeError:
+            return self.is_alive()
+
     def start(self):
-        if not self.isAlive():
+        if not self.alive():
             self.stop_event.clear()
             threading.Thread.start(self)
 
     def stop(self):
-        if self.isAlive():
+        if self.alive():
             self.stop_event.set()
             self.join()
 

--- a/library/setup.py
+++ b/library/setup.py
@@ -50,5 +50,5 @@ setup(
     url         = 'http://shop.pimoroni.com',
     classifiers = classifiers,
     packages    = ['explorerhat'],
-    install_requires= ['cap1xxx']
+    install_requires= ['cap1xxx>=0.1.4']
 )


### PR DESCRIPTION
Thread.isAlive is now Thread.is_alive, add shim to smooth over the change.

Requires https://github.com/pimoroni/cap1xxx/pull/21